### PR TITLE
fixed weight mistake

### DIFF
--- a/RUSBoost.py
+++ b/RUSBoost.py
@@ -43,7 +43,7 @@ class RUSBoost:
 
             sampled = self.undersampling()
 
-            sampled_weight = [s[0] for s in sampled]
+            sampled_weight = [self.weight[s[0]] for s in sampled]
             sampled_X      = [s[1] for s in sampled]
             sample_Y       = [s[2] for s in sampled]
 


### PR DESCRIPTION
I made a mistake when pulling the new sampled weights from the undersampling method. I simply took the indexes before, now I use the indexes to get the weights. I fixed it now. 